### PR TITLE
Exit with a non-zero status when the requested type is unavailable

### DIFF
--- a/pbv.swift
+++ b/pbv.swift
@@ -37,9 +37,11 @@ func printPasteboard(_ pasteboard: NSPasteboard, dataTypeName: String) {
   let dataType = NSPasteboard.PasteboardType(rawValue: dataTypeName)
   if let string = pasteboard.string(forType: dataType) {
     print(string, terminator: "")
+    exit(0)
   } else {
     printErr("Could not access pasteboard contents as String for type '\(dataTypeName)'")
     printTypes(pasteboard)
+    exit(1)
   }
 }
 


### PR DESCRIPTION
I think programs that call this script will want to detect this case. An error code seems like a good method for communicating that this case was reached.

For now I used the same non-zero exit code as for when too many arguments are provided. I didn’t want to assign different codes to those cases until I was sure that the program wouldn’t add more error cases to consider in the numbering scheme.

I know that the `exit(0)` is not strictly necessary, but it makes it clearer that the program will always exit after `printPasteboard` completes.